### PR TITLE
Json option has been deprecated

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,7 +5,7 @@ const { join } = require('path')
 
 const DEFAULT_OUTPUT = join(__dirname, './stats.html')
 
-cli.option('--template -t <template>', 'Template to use, options are "json", "treemap", "sunburst" and "network"', {
+cli.option('--template -t <template>', 'Template to use, options are "raw-data" (JSON), "treemap", "list", "sunburst" and "network"', {
   default: 'treemap'
 })
 cli.option('--output -o <filepath>', 'Output file path, should be "**/*.html" or "**/*.json"', {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const start = ({
 
   let outFile
 
-  if (template === 'json') {
+  if (template === 'raw-data') {
     outFile = output.replace(/\.html$/, '.json')
     open = false
     console.log(`Generating ${template} result to ${outFile}...\n`)
@@ -29,7 +29,7 @@ const start = ({
 
 
   build({
-    plugins: [visualizer({ open, filename: outFile, title: 'Vite Bundle Visualizer', template, json: template === 'json' })]
+    plugins: [visualizer({ open, filename: outFile, title: 'Vite Bundle Visualizer', template })]
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test:demo": "cd demo && node ../bin.js"
   },
   "dependencies": {
-    "cac": "^6.7.12",
-    "rollup-plugin-visualizer": "^5.7.1"
+    "cac": "^6.7.14",
+    "rollup-plugin-visualizer": "^5.9.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,13 +2,13 @@ lockfileVersion: 5.4
 
 specifiers:
   '@types/node': ^18.0.0
-  cac: ^6.7.12
+  cac: ^6.7.14
   release-it: ^15.1.2
-  rollup-plugin-visualizer: ^5.7.1
+  rollup-plugin-visualizer: ^5.9.0
 
 dependencies:
-  cac: 6.7.12
-  rollup-plugin-visualizer: 5.7.1
+  cac: 6.7.14
+  rollup-plugin-visualizer: 5.9.0
 
 devDependencies:
   '@types/node': 18.0.6
@@ -396,8 +396,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /cac/6.7.12:
-    resolution: {integrity: sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==}
+  /cac/6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
     dev: false
 
@@ -1654,12 +1654,6 @@ packages:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: true
 
-  /nanoid/3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: false
-
   /netmask/2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -1907,7 +1901,6 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /prelude-ls/1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -2150,15 +2143,18 @@ packages:
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
-  /rollup-plugin-visualizer/5.7.1:
-    resolution: {integrity: sha512-E/IgOMnmXKlc6ICyf53ok1b6DxPeNVUs3R0kYYPuDpGfofT4bkiG+KtSMlGjMACFmfwbbqTVDZBIF7sMZVKJbA==}
+  /rollup-plugin-visualizer/5.9.0:
+    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
-      rollup: ^2.0.0
+      rollup: 2.x || 3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
     dependencies:
-      nanoid: 3.3.4
       open: 8.4.0
+      picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.5.1
     dev: false


### PR DESCRIPTION
Hello,

That's a cool lib but it shows a deprecated message when we use it with npx because it uses the last version of rollup-plugin-visualizer that has deprecated the json option

<img width="355" alt="image" src="https://user-images.githubusercontent.com/91051687/220120727-b7f36bc5-0bb9-4bce-8dca-d60663fcc608.png">

The goal of this PR is small and simple: replace the Json option by raw-data value for template option